### PR TITLE
artifact: Add eval script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ We assume you are on **Ubuntu 20.04**.
 sudo apt install -y build-essential rsync opam
 opam init
 opam switch create 4.10.0  # or later. If your system OCaml version is >= 4.10.0, you can use it.
+eval $(opam env)
 opam update
 ```
 


### PR DESCRIPTION
일단은 명시적으로 `eval $(opam env)`를 넣었습니다.
(opam 설치하면 실행하라고 출력되는 문구라 굳이 필요할까 생각이 들지만...)

vm에 ubuntu 새로 깔아서 돌려봤는데
해주지 않으면 coq, model checker 모두 에러가 납니다.